### PR TITLE
Allow the call of queryInventory method at any time from any thread

### DIFF
--- a/dependencies/android/src/org/haxe/extension/iap/InAppPurchase.java
+++ b/dependencies/android/src/org/haxe/extension/iap/InAppPurchase.java
@@ -69,9 +69,17 @@ public class InAppPurchase extends Extension {
 
 	}
 	
-	public static void queryInventory (boolean querySkuDetails, String[] moreSkusArr) {
-		List<String> moreSkus = Arrays.asList(moreSkusArr); 
-		InAppPurchase.inAppPurchaseHelper.queryInventoryAsync(querySkuDetails, moreSkus, mGotInventoryListener);
+	public static void queryInventory (final boolean querySkuDetails, String[] moreSkusArr) {
+		final List<String> moreSkus = Arrays.asList(moreSkusArr); 
+		Extension.mainActivity.runOnUiThread(new Runnable() {
+			public void run() {
+				try {
+					InAppPurchase.inAppPurchaseHelper.queryInventoryAsync(querySkuDetails, moreSkus, mGotInventoryListener);
+				} catch(Exception e) {
+					Log.d("IAP", e.getMessage());
+				}
+			}
+		});
 	}
 	
 	public static String getPublicKey () {


### PR DESCRIPTION
If you call queryInventory outside from any of the callback methods of the extension, the app just stopped working.
This way it works in both cases (from the app callbacks and from any other place on any thread).