### PR TITLE
[iOS] Fixed localizedPrice + Added priceAmountMicros and priceCurrencyCode

### DIFF
--- a/extension/iap/IAP.hx
+++ b/extension/iap/IAP.hx
@@ -392,6 +392,10 @@ typedef IAProduct = {
 				dispatchEvent (new IAPEvent (IAPEvent.PURCHASE_PRODUCT_DATA_COMPLETE, null, tempProductsData));
 				tempProductsData.splice(0, tempProductsData.length);
 			
+			case "productDataFailed":
+				
+				dispatchEvent (new IAPEvent (IAPEvent.PURCHASE_PRODUCT_DATA_FAILED, data));
+			
 			default:
 			
 		}

--- a/extension/iap/IAP.hx
+++ b/extension/iap/IAP.hx
@@ -382,10 +382,9 @@ typedef IAProduct = {
 				dispatchEvent (e);
 			
 			case "productData":
-				var prod:IAProduct = { productID: Reflect.field (inEvent, "productID"), localizedTitle: Reflect.field (inEvent, "localizedTitle"), localizedDescription: Reflect.field (inEvent, "localizedDescription"), price: Reflect.field (inEvent, "price") };
-				trace('   ios product: ' + prod);
-				tempProductsData.push(prod );
-				
+				var prod:IAProduct = { productID: Reflect.field (inEvent, "productID"), localizedTitle: Reflect.field (inEvent, "localizedTitle"), localizedDescription: Reflect.field (inEvent, "localizedDescription"), localizedPrice: Reflect.field (inEvent, "localizedPrice"), priceAmountMicros: Reflect.field (inEvent, "priceAmountMicros"), price: Reflect.field(inEvent, "priceAmountMicros")/1000/1000, priceCurrencyCode: Reflect.field (inEvent, "priceCurrencyCode")};
+				trace('iOS Product: ' + prod);
+				tempProductsData.push( prod );				
 				inventory.productDetailsMap.set(prod.productID, new ProductDetails(prod));
 				
 			case "productDataComplete":

--- a/extension/iap/IAPEvent.hx
+++ b/extension/iap/IAPEvent.hx
@@ -18,6 +18,7 @@ class IAPEvent extends Event {
 	public static inline var PURCHASE_CONSUME_SUCCESS = "consumeSuccess";
 	public static inline var PURCHASE_CONSUME_FAILURE = "consumeFailed";
 	public static inline var PURCHASE_PRODUCT_DATA_COMPLETE = "productDataComplete";
+	public static inline var PURCHASE_PRODUCT_DATA_FAILED = "productDataFailed";
 	public static inline var PURCHASE_QUERY_INVENTORY_COMPLETE = "queryInventoryComplete";
 	public static inline var PURCHASE_QUERY_INVENTORY_FAILED = "queryInventoryFailed";
 	public static inline var DOWNLOAD_COMPLETE = "downloadComplete";

--- a/extension/iap/ProductDetails.hx
+++ b/extension/iap/ProductDetails.hx
@@ -17,16 +17,19 @@ class ProductDetails
 		// Handle both Android and iOS Ids
 		productID = Reflect.hasField(dynObj, "productId")? Reflect.field(dynObj, "productId") : Reflect.field(dynObj, "productID");
 		type = cast Reflect.field(dynObj, "type");
-		localizedPrice = cast Reflect.field(dynObj, "price");
-		priceAmountMicros = cast Reflect.field(dynObj, "price_amount_micros");
-		price = priceAmountMicros / 1000 / 1000;
-		priceCurrencyCode = cast Reflect.field(dynObj, "price_currency_code");
 		localizedTitle = cast Reflect.field(dynObj, "title");
 		#if ios
+			localizedPrice = cast Reflect.field(dynObj, "localizedPrice");
+			priceAmountMicros = cast Reflect.field(dynObj, "priceAmountMicros");
+			priceCurrencyCode = cast Reflect.field(dynObj, "priceCurrencyCode");
 			localizedDescription = cast Reflect.field(dynObj, "localizedDescription");
 		#else
+			localizedPrice = cast Reflect.field(dynObj, "price");
+			priceAmountMicros = cast Reflect.field(dynObj, "price_amount_micros");
+			priceCurrencyCode = cast Reflect.field(dynObj, "price_currency_code");
 			localizedDescription = cast Reflect.field(dynObj, "description");
 		#end
+		price = priceAmountMicros / 1000 / 1000;
 	}
 	
 	public function toString() :String {

--- a/project/common/ExternalInterface.cpp
+++ b/project/common/ExternalInterface.cpp
@@ -135,15 +135,16 @@ extern "C" void sendPurchaseDownloadEvent(const char* type, const char* productI
 }
 
 
-extern "C" void sendPurchaseProductDataEvent(const char* type, const char* productID, const char* localizedTitle, const char* localizedDescription, float price, const char* localizedPrice)
+extern "C" void sendPurchaseProductDataEvent(const char* type, const char* productID, const char* localizedTitle, const char* localizedDescription, int priceAmountMicros, const char* localizedPrice, const char* priceCurrencyCode)
 {
     value o = alloc_empty_object();
     alloc_field(o,val_id("type"),alloc_string(type));
     alloc_field(o,val_id("productID"),alloc_string(productID));
 	alloc_field(o,val_id("localizedTitle"),alloc_string(localizedTitle));
 	alloc_field(o,val_id("localizedDescription"),alloc_string(localizedDescription));
-  alloc_field(o,val_id("price"),alloc_float(price));
-	alloc_field(o,val_id("price"),alloc_string(localizedPrice));
+	alloc_field(o,val_id("priceAmountMicros"),alloc_int(priceAmountMicros));
+	alloc_field(o,val_id("localizedPrice"),alloc_string(localizedPrice));
+	alloc_field(o,val_id("priceCurrencyCode"),alloc_string(priceCurrencyCode));
     val_call1(purchaseEventHandle->get(), o);
 }
 

--- a/project/iphone/InAppPurchase.mm
+++ b/project/iphone/InAppPurchase.mm
@@ -8,7 +8,7 @@
 extern "C" void sendPurchaseEvent(const char* type, const char* data);
 extern "C" void sendPurchaseFinishEvent(const char* type, const char* productID, const char* transactionID, double transactionDate, const char* receipt);
 extern "C" void sendPurchaseDownloadEvent(const char* type, const char* productID, const char* transactionID, const char* downloadPath, const char* downloadVersion, const char* downloadProgress);
-extern "C" void sendPurchaseProductDataEvent(const char* type, const char* productID, const char* localizedTitle, const char* localizedDescription, const char* price);
+extern "C" void sendPurchaseProductDataEvent(const char* type, const char* productID, const char* localizedTitle, const char* localizedDescription, int priceAmountMicros, const char* localizedPrice, const char* priceCurrencyCode);
 
 
 @interface InAppPurchase: NSObject <SKProductsRequestDelegate, SKPaymentTransactionObserver>
@@ -116,8 +116,13 @@ extern "C" void sendPurchaseProductDataEvent(const char* type, const char* produ
 				[numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
 				[numberFormatter setLocale:prod.priceLocale];
 				NSString *formattedPrice = [numberFormatter stringFromNumber:prod.price];
+				[numberFormatter release];
+				
+				NSString *priceCurrencyCode = [prod.priceLocale objectForKey:NSLocaleCurrencyCode];
 
-				sendPurchaseProductDataEvent("productData", [prod.productIdentifier UTF8String], [prod.localizedTitle UTF8String], [prod.localizedDescription UTF8String], [formattedPrice UTF8String]);
+				int priceAmountMicros = [[prod.price decimalNumberByMultiplyingBy:[NSDecimalNumber decimalNumberWithString:@"1000000"]] intValue];			
+
+				sendPurchaseProductDataEvent("productData", [prod.productIdentifier UTF8String], [prod.localizedTitle UTF8String], [prod.localizedDescription UTF8String], priceAmountMicros, [formattedPrice UTF8String], [priceCurrencyCode UTF8String]);
 
 			}
 			


### PR DESCRIPTION
localizedPrice was not working (since the objective C part was providing a String while the C++ Extern was expecting a Float), so Haxe was just receiving memory trash, and placing it as a String on a Float field.

Now objective C informs priceAmountMicros, localizedPrice and priceCurrencyCode, so Android and iOS works really similar and provides almost the same information.