### PR TITLE
[iOS] General Fixes

### DIFF
--- a/extension/iap/IAP.hx
+++ b/extension/iap/IAP.hx
@@ -382,10 +382,9 @@ typedef IAProduct = {
 				dispatchEvent (e);
 			
 			case "productData":
-				var prod:IAProduct = { productID: Reflect.field (inEvent, "productID"), localizedTitle: Reflect.field (inEvent, "localizedTitle"), localizedDescription: Reflect.field (inEvent, "localizedDescription"), price: Reflect.field (inEvent, "price"), localizedPrice: Reflect.field (inEvent, "localizedPrice") };
-				trace('   ios product: ' + prod);
-				tempProductsData.push(prod );
-				
+				var prod:IAProduct = { productID: Reflect.field (inEvent, "productID"), localizedTitle: Reflect.field (inEvent, "localizedTitle"), localizedDescription: Reflect.field (inEvent, "localizedDescription"), localizedPrice: Reflect.field (inEvent, "localizedPrice"), priceAmountMicros: Reflect.field (inEvent, "priceAmountMicros"), price: Reflect.field(inEvent, "priceAmountMicros")/1000/1000, priceCurrencyCode: Reflect.field (inEvent, "priceCurrencyCode")};
+				trace('iOS Product: ' + prod);
+				tempProductsData.push( prod );				
 				inventory.productDetailsMap.set(prod.productID, new ProductDetails(prod));
 				
 			case "productDataComplete":
@@ -395,8 +394,8 @@ typedef IAProduct = {
 			
 			case "productDataFailed":
 				
-				dispatchEvent (new IAPEvent (IAPEvent.PURCHASE_PRODUCT_DATA_FAILED, null));
-				
+				dispatchEvent (new IAPEvent (IAPEvent.PURCHASE_PRODUCT_DATA_FAILED, data));
+			
 			default:
 			
 		}

--- a/extension/iap/ProductDetails.hx
+++ b/extension/iap/ProductDetails.hx
@@ -17,16 +17,19 @@ class ProductDetails
 		// Handle both Android and iOS Ids
 		productID = Reflect.hasField(dynObj, "productId")? Reflect.field(dynObj, "productId") : Reflect.field(dynObj, "productID");
 		type = cast Reflect.field(dynObj, "type");
-		localizedPrice = cast Reflect.field(dynObj, "price");
-		priceAmountMicros = cast Reflect.field(dynObj, "price_amount_micros");
-		price = priceAmountMicros / 1000 / 1000;
-		priceCurrencyCode = cast Reflect.field(dynObj, "price_currency_code");
 		localizedTitle = cast Reflect.field(dynObj, "title");
 		#if ios
+			localizedPrice = cast Reflect.field(dynObj, "localizedPrice");
+			priceAmountMicros = cast Reflect.field(dynObj, "priceAmountMicros");
+			priceCurrencyCode = cast Reflect.field(dynObj, "priceCurrencyCode");
 			localizedDescription = cast Reflect.field(dynObj, "localizedDescription");
 		#else
+			localizedPrice = cast Reflect.field(dynObj, "price");
+			priceAmountMicros = cast Reflect.field(dynObj, "price_amount_micros");
+			priceCurrencyCode = cast Reflect.field(dynObj, "price_currency_code");
 			localizedDescription = cast Reflect.field(dynObj, "description");
 		#end
+		price = priceAmountMicros / 1000 / 1000;
 	}
 	
 	public function toString() :String {

--- a/project/common/ExternalInterface.cpp
+++ b/project/common/ExternalInterface.cpp
@@ -135,15 +135,16 @@ extern "C" void sendPurchaseDownloadEvent(const char* type, const char* productI
 }
 
 
-extern "C" void sendPurchaseProductDataEvent(const char* type, const char* productID, const char* localizedTitle, const char* localizedDescription, float price, const char* localizedPrice)
+extern "C" void sendPurchaseProductDataEvent(const char* type, const char* productID, const char* localizedTitle, const char* localizedDescription, int priceAmountMicros, const char* localizedPrice, const char* priceCurrencyCode)
 {
     value o = alloc_empty_object();
     alloc_field(o,val_id("type"),alloc_string(type));
     alloc_field(o,val_id("productID"),alloc_string(productID));
 	alloc_field(o,val_id("localizedTitle"),alloc_string(localizedTitle));
 	alloc_field(o,val_id("localizedDescription"),alloc_string(localizedDescription));
-  alloc_field(o,val_id("price"),alloc_float(price));
+	alloc_field(o,val_id("priceAmountMicros"),alloc_int(priceAmountMicros));
 	alloc_field(o,val_id("localizedPrice"),alloc_string(localizedPrice));
+	alloc_field(o,val_id("priceCurrencyCode"),alloc_string(priceCurrencyCode));
     val_call1(purchaseEventHandle->get(), o);
 }
 


### PR DESCRIPTION
Add priceCurrencyCode and priceAmountMicros.
Send data on PURCHASE_PRODUCT_DATA_FAILED event.
Unify Android and iOS fields on ProductDetails.
When a network error happens, tell if it's during product date request, or a purchase.