### PR TITLE
replace alloc_string with safe_alloc_string (to avoid crashes)

### DIFF
--- a/project/common/ExternalInterface.cpp
+++ b/project/common/ExternalInterface.cpp
@@ -70,7 +70,7 @@ DEFINE_PRIM(iap_finish_transaction, 1);
 
 static value iap_canbuy() 
 {
-   	printf("init 222222 can buy --------------------------------------------------- xx\n");
+	printf("init 222222 can buy --------------------------------------------------- xx\n");
 	return alloc_bool(canPurchase());
 }
 DEFINE_PRIM (iap_canbuy, 0);
@@ -114,47 +114,47 @@ extern "C" int iap_register_prims() { return 0; }
 
 extern "C" void sendPurchaseEvent(const char* type, const char* data)
 {
-    value o = alloc_empty_object();
-    alloc_field(o,val_id("type"),safe_alloc_string(type));
-    alloc_field(o,val_id("data"),safe_alloc_string(data));
-    val_call1(purchaseEventHandle->get(), o);
+	value o = alloc_empty_object();
+	alloc_field(o,val_id("type"),safe_alloc_string(type));
+	alloc_field(o,val_id("data"),safe_alloc_string(data));
+	val_call1(purchaseEventHandle->get(), o);
 }
 
 
 extern "C" void sendPurchaseDownloadEvent(const char* type, const char* productID, const char* transactionID, const char* downloadPath, const char* downloadVersion, const char* downloadProgress)
 {
-    value o = alloc_empty_object();
-    alloc_field(o,val_id("type"),safe_alloc_string(type));
-    alloc_field(o,val_id("productID"),safe_alloc_string(productID));
+	value o = alloc_empty_object();
+	alloc_field(o,val_id("type"),safe_alloc_string(type));
+	alloc_field(o,val_id("productID"),safe_alloc_string(productID));
 	alloc_field(o,val_id("transactionID"),safe_alloc_string(transactionID));
 	alloc_field(o,val_id("downloadPath"),safe_alloc_string(downloadPath));
 	alloc_field(o,val_id("downloadVersion"),safe_alloc_string(downloadVersion));
 	alloc_field(o,val_id("downloadProgress"),safe_alloc_string(downloadProgress));
-    val_call1(purchaseEventHandle->get(), o);
+	val_call1(purchaseEventHandle->get(), o);
 }
 
 
 extern "C" void sendPurchaseProductDataEvent(const char* type, const char* productID, const char* localizedTitle, const char* localizedDescription, int priceAmountMicros, const char* localizedPrice, const char* priceCurrencyCode)
 {
-    value o = alloc_empty_object();
-    alloc_field(o,val_id("type"),safe_alloc_string(type));
-    alloc_field(o,val_id("productID"),safe_alloc_string(productID));
+	value o = alloc_empty_object();
+	alloc_field(o,val_id("type"),safe_alloc_string(type));
+	alloc_field(o,val_id("productID"),safe_alloc_string(productID));
 	alloc_field(o,val_id("localizedTitle"),safe_alloc_string(localizedTitle));
 	alloc_field(o,val_id("localizedDescription"),safe_alloc_string(localizedDescription));
 	alloc_field(o,val_id("priceAmountMicros"),alloc_int(priceAmountMicros));
 	alloc_field(o,val_id("localizedPrice"),safe_alloc_string(localizedPrice));
 	alloc_field(o,val_id("priceCurrencyCode"),safe_alloc_string(priceCurrencyCode));
-    val_call1(purchaseEventHandle->get(), o);
+	val_call1(purchaseEventHandle->get(), o);
 }
 
 
 extern "C" void sendPurchaseFinishEvent(const char* type, const char* productID, const char* transactionID, double transactionDate, const char* receipt)
 {
-    value o = alloc_empty_object();
-    alloc_field(o,val_id("type"),safe_alloc_string(type));
-    alloc_field(o,val_id("productID"),safe_alloc_string(productID));
+	value o = alloc_empty_object();
+	alloc_field(o,val_id("type"),safe_alloc_string(type));
+	alloc_field(o,val_id("productID"),safe_alloc_string(productID));
 	alloc_field(o,val_id("transactionID"),safe_alloc_string(transactionID));
 	alloc_field(o,val_id("transactionDate"),alloc_int(static_cast<int>(transactionDate)));
-    alloc_field(o,val_id("receipt"),safe_alloc_string(receipt));
-    val_call1(purchaseEventHandle->get(), o);
+	alloc_field(o,val_id("receipt"),safe_alloc_string(receipt));
+	val_call1(purchaseEventHandle->get(), o);
 }

--- a/project/common/ExternalInterface.cpp
+++ b/project/common/ExternalInterface.cpp
@@ -12,6 +12,7 @@
 #include "InAppPurchase.h"
 #include "InAppPurchaseEvent.h"
 
+#define safe_alloc_string(a) (a!=NULL?alloc_string(a):NULL)
 
 using namespace iap;
 
@@ -114,10 +115,8 @@ extern "C" int iap_register_prims() { return 0; }
 extern "C" void sendPurchaseEvent(const char* type, const char* data)
 {
     value o = alloc_empty_object();
-    alloc_field(o,val_id("type"),alloc_string(type));
-	
-    if (data != NULL) alloc_field(o,val_id("data"),alloc_string(data));
-	
+    alloc_field(o,val_id("type"),safe_alloc_string(type));
+    alloc_field(o,val_id("data"),safe_alloc_string(data));
     val_call1(purchaseEventHandle->get(), o);
 }
 
@@ -125,12 +124,12 @@ extern "C" void sendPurchaseEvent(const char* type, const char* data)
 extern "C" void sendPurchaseDownloadEvent(const char* type, const char* productID, const char* transactionID, const char* downloadPath, const char* downloadVersion, const char* downloadProgress)
 {
     value o = alloc_empty_object();
-    alloc_field(o,val_id("type"),alloc_string(type));
-    alloc_field(o,val_id("productID"),alloc_string(productID));
-	alloc_field(o,val_id("transactionID"),alloc_string(transactionID));
-	if (downloadPath != NULL) alloc_field(o,val_id("downloadPath"),alloc_string(downloadPath));
-	if (downloadVersion != NULL) alloc_field(o,val_id("downloadVersion"),alloc_string(downloadVersion));
-	if (downloadProgress != NULL) alloc_field(o,val_id("downloadProgress"),alloc_string(downloadProgress));
+    alloc_field(o,val_id("type"),safe_alloc_string(type));
+    alloc_field(o,val_id("productID"),safe_alloc_string(productID));
+	alloc_field(o,val_id("transactionID"),safe_alloc_string(transactionID));
+	alloc_field(o,val_id("downloadPath"),safe_alloc_string(downloadPath));
+	alloc_field(o,val_id("downloadVersion"),safe_alloc_string(downloadVersion));
+	alloc_field(o,val_id("downloadProgress"),safe_alloc_string(downloadProgress));
     val_call1(purchaseEventHandle->get(), o);
 }
 
@@ -138,13 +137,13 @@ extern "C" void sendPurchaseDownloadEvent(const char* type, const char* productI
 extern "C" void sendPurchaseProductDataEvent(const char* type, const char* productID, const char* localizedTitle, const char* localizedDescription, int priceAmountMicros, const char* localizedPrice, const char* priceCurrencyCode)
 {
     value o = alloc_empty_object();
-    alloc_field(o,val_id("type"),alloc_string(type));
-    alloc_field(o,val_id("productID"),alloc_string(productID));
-	alloc_field(o,val_id("localizedTitle"),alloc_string(localizedTitle));
-	alloc_field(o,val_id("localizedDescription"),alloc_string(localizedDescription));
+    alloc_field(o,val_id("type"),safe_alloc_string(type));
+    alloc_field(o,val_id("productID"),safe_alloc_string(productID));
+	alloc_field(o,val_id("localizedTitle"),safe_alloc_string(localizedTitle));
+	alloc_field(o,val_id("localizedDescription"),safe_alloc_string(localizedDescription));
 	alloc_field(o,val_id("priceAmountMicros"),alloc_int(priceAmountMicros));
-	alloc_field(o,val_id("localizedPrice"),alloc_string(localizedPrice));
-	alloc_field(o,val_id("priceCurrencyCode"),alloc_string(priceCurrencyCode));
+	alloc_field(o,val_id("localizedPrice"),safe_alloc_string(localizedPrice));
+	alloc_field(o,val_id("priceCurrencyCode"),safe_alloc_string(priceCurrencyCode));
     val_call1(purchaseEventHandle->get(), o);
 }
 
@@ -152,10 +151,10 @@ extern "C" void sendPurchaseProductDataEvent(const char* type, const char* produ
 extern "C" void sendPurchaseFinishEvent(const char* type, const char* productID, const char* transactionID, double transactionDate, const char* receipt)
 {
     value o = alloc_empty_object();
-    alloc_field(o,val_id("type"),alloc_string(type));
-    alloc_field(o,val_id("productID"),alloc_string(productID));
-	alloc_field(o,val_id("transactionID"),alloc_string(transactionID));
+    alloc_field(o,val_id("type"),safe_alloc_string(type));
+    alloc_field(o,val_id("productID"),safe_alloc_string(productID));
+	alloc_field(o,val_id("transactionID"),safe_alloc_string(transactionID));
 	alloc_field(o,val_id("transactionDate"),alloc_int(static_cast<int>(transactionDate)));
-    alloc_field(o,val_id("receipt"),alloc_string(receipt));
+    alloc_field(o,val_id("receipt"),safe_alloc_string(receipt));
     val_call1(purchaseEventHandle->get(), o);
 }


### PR DESCRIPTION
On some cases (specially on sandbox), some of the strings sent by the extension were null and made the alloc_string function to fail.