### PR TITLE
Handle empty Product Data case with event

### DIFF
--- a/extension/iap/IAPEvent.hx
+++ b/extension/iap/IAPEvent.hx
@@ -19,6 +19,7 @@ class IAPEvent extends Event {
 	public static inline var PURCHASE_CONSUME_FAILURE = "consumeFailed";
 	public static inline var PURCHASE_PRODUCT_DATA_COMPLETE = "productDataComplete";
 	public static inline var PURCHASE_PRODUCT_DATA_FAILED = "productDataFailed";
+	public static inline var PURCHASE_PRODUCT_DATA_EMPTY = "productDataEmpty";
 	public static inline var PURCHASE_QUERY_INVENTORY_COMPLETE = "queryInventoryComplete";
 	public static inline var PURCHASE_QUERY_INVENTORY_FAILED = "queryInventoryFailed";
 	public static inline var DOWNLOAD_COMPLETE = "downloadComplete";

--- a/extension/iap/ios/IAP.hx
+++ b/extension/iap/ios/IAP.hx
@@ -291,6 +291,10 @@ import haxe.Json;
 
 				dispatchEvent (new IAPEvent (IAPEvent.PURCHASE_PRODUCT_DATA_FAILED, data));
 
+			case "productDataEmpty":
+
+				dispatchEvent (new IAPEvent (IAPEvent.PURCHASE_PRODUCT_DATA_EMPTY, data));
+
 			default:
 
 		}

--- a/project/iphone/InAppPurchase.mm
+++ b/project/iphone/InAppPurchase.mm
@@ -158,6 +158,7 @@ extern "C" void sendPurchaseProductDataEvent(const char* type, const char* produ
     else 
     {
 		NSLog(@"No products are available");
+		sendPurchaseEvent("productDataEmpty", nil);
 	}
 }
 


### PR DESCRIPTION
Currently when the product Data is empty, no callback will be called on
haxe's side. This isn't good for cases when e.g. a promise is waiting
to be fulfilled.

Now this can be handled by listening for
PURCHASE_PRODUCT_DATA_EMPTY
