### PR TITLE
iOS: updated finish transaction logic, HX code is better unified with the Android version

### DIFF
--- a/extension/iap/Inventory.hx
+++ b/extension/iap/Inventory.hx
@@ -71,7 +71,7 @@ class Inventory
 	}
 	
 	/** Returns purchase information for a given product, or null if there is no purchase. */
-    public function getPurchase(productId:String) :Purchase {
+    public function getPurchase(productId:String): Purchase {
         return purchaseMap.get(productId);
     }
 

--- a/extension/iap/Purchase.hx
+++ b/extension/iap/Purchase.hx
@@ -18,10 +18,12 @@ class Purchase
 	public var purchaseState(default, null):Int;
 	public var developerPayload(default, null):String;
 	public var purchaseToken(default, null):String;
-	public var acknowledged(default, null):Bool;
 	public var signature(default, null):String;
 	public var originalJson(default, null):String;
 	public var json(default, null):String;
+
+	// iOS and Android Properties
+	public var acknowledged(default, null):Bool;
 
 	// iOS Properties
 	public var transactionID(default, null):String;

--- a/extension/iap/Purchase.hx
+++ b/extension/iap/Purchase.hx
@@ -78,6 +78,12 @@ class Purchase
 		
 		this.originalJson = originalJson;
 	}
+
+    #if ios
+    public function acknowledge(): Void {
+      acknowledged = true;
+    }
+    #end
 	
 	public function toString() :String {
 		var res:String = "Purchase: { ";

--- a/extension/iap/ios/IAP.hx
+++ b/extension/iap/ios/IAP.hx
@@ -179,8 +179,9 @@ class IAP {
 	 * 		PURCHASE_CONSUME_FAILURE: Fired when the consume attempt failed
 	 */
 
-	public static function consume (purchase:Purchase) : Void {
-		purchases_finish_transaction (purchase.transactionID);
+	public static function consume (purchase:Purchase): Void {
+		purchases_finish_transaction(purchase.transactionID);
+		IAP.inventory.erasePurchase(purchase.productID);		
 	}
 
 	/**
@@ -193,10 +194,20 @@ class IAP {
 	 * 		PURCHASE_ACKNOWLEDGE_FAILURE: Fired when the acknowledgePurchase attempt failed
 	 */
 
-	 public static function acknowledgePurchase (purchase:Purchase):Void {
+	public static function acknowledgePurchase (purchase: Purchase): Void {
+		purchases_finish_transaction(purchase.transactionID);
+		var inventoryPurchase: Purchase = IAP.inventory.getPurchase(purchase.productID);
 
-		//TODO
+		// to let check if the purchase was already acknowledged (meaning the transaction already finished)
+		if (inventoryPurchase != null) inventoryPurchase.acknowledged = true; 
 	}
+
+	// added for consistency with Android version. Fires the success callback immediately
+	public static function queryInventory (_, _): Void {
+		var evt: IAPEvent = new IAPEvent(IAPEvent.QUERY_INVENTORY_COMPLETE);
+		IAP.dispatchEvent(evt);
+	}
+
 
 	/**
 	 * Manually finishes a transaction from the SKPaymentQueue. If <code>manualTransactionMode</code> is false,

--- a/extension/iap/ios/IAP.hx
+++ b/extension/iap/ios/IAP.hx
@@ -199,11 +199,11 @@ class IAP {
 		var inventoryPurchase: Purchase = IAP.inventory.getPurchase(purchase.productID);
 
 		// to let check if the purchase was already acknowledged (meaning the transaction already finished)
-		if (inventoryPurchase != null) inventoryPurchase.acknowledged = true; 
+		if (inventoryPurchase != null) inventoryPurchase.acknowledge(); 
 	}
 
 	// added for consistency with Android version. Fires the success callback immediately
-	public static function queryInventory (_, _): Void {
+	public static function queryInventory (queryItemDetails:Bool = false, moreItems:Array<String> = null): Void {
 		var evt: IAPEvent = new IAPEvent(IAPEvent.QUERY_INVENTORY_COMPLETE);
 		IAP.dispatchEvent(evt);
 	}

--- a/project/iphone/InAppPurchase.mm
+++ b/project/iphone/InAppPurchase.mm
@@ -66,7 +66,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 		preInited = true;
 		static dispatch_once_t onceToken;
 		manualTransactionMode = true;
-		nslog(@"extIAP mm: xxxxxxx purchase init v2");
+		NSLog(@"extIAP mm: xxxxxxx purchase init v2");
 		//dispatch_once(&onceToken, ^{
 			[[SKPaymentQueue defaultQueue] addTransactionObserver:self];
 		//});
@@ -85,14 +85,14 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
 - (void)checkQueue
 {
-    nslog(@"extIAP mm: checkQueue");
+    NSLog(@"extIAP mm: checkQueue");
     
 	[self paymentQueue:[SKPaymentQueue defaultQueue] updatedTransactions:[[SKPaymentQueue defaultQueue] transactions]];
 }
 
 - (void)restorePurchases 
 {
-	nslog(@"extIAP mm: starting restore");
+	NSLog(@"extIAP mm: starting restore");
 	[[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 
@@ -106,14 +106,14 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 	SKProduct* product = [self findProduct:productIdentifiers];//findProduct(productIdentifiers);
 	if (product != nil)
 	{
-		nslog(@"extIAP mm: product found");
+		NSLog(@"extIAP mm: product found");
 		SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
         	payment.quantity = 1;
 		[[SKPaymentQueue defaultQueue] addPayment:payment];
 	}
 	else
 	{
-		nslog(@"extIAP mm: product not found");
+		NSLog(@"extIAP mm: product not found");
 	}
 } 
 
@@ -121,7 +121,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 {
 	if(productsRequest != NULL)
 	{
-		nslog(@"extIAP mm: Can't request product data while performing a previous transaction.");
+		NSLog(@"extIAP mm: Can't request product data while performing a previous transaction.");
 		return;
 	}
 
@@ -150,7 +150,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
 - (void)request:(SKProductsRequest *)request didFailWithError:(NSError *)error
 {
-	nslog(@"extIAP mm: Error: %@",error);
+	NSLog(@"extIAP mm: Error: %@",error);
 	if( productsRequest == request ) productsRequest = NULL;
 	
 	sendPurchaseEventWrap("productDataFailed", error.localizedDescription);
@@ -159,8 +159,8 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse*)response
 {   	
 	int count = [response.products count];
-    	nslog(@"extIAP mm: productsRequest");
-	nslog(@"extIAP mm: Number of Products: %i", count);
+    	NSLog(@"extIAP mm: productsRequest");
+	NSLog(@"extIAP mm: Number of Products: %i", count);
 
 	// release the products request BEFORE calling the completion to support calling purchase()
 	// in the completion result handlers
@@ -197,7 +197,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
     
     else 
     {
-		nslog(@"extIAP mm: No products are available");
+		NSLog(@"extIAP mm: No products are available");
 	}
 }
 
@@ -214,7 +214,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
         }
 
         // transaction identifier was not found, quick developer log and return failure
-        nslog(@"extIAP mm: Failed to complete transaction manually. [expected_transaction=%@; open_transactions=%@]", transactionID, [[transactions valueForKey:@"transactionIdentifier"] componentsJoinedByString:@", "]);
+        NSLog(@"extIAP mm: Failed to complete transaction manually. [expected_transaction=%@; open_transactions=%@]", transactionID, [[transactions valueForKey:@"transactionIdentifier"] componentsJoinedByString:@", "]);
     }
     return false;
 }
@@ -229,7 +229,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
         }*/
 
         @try {
-            nslog(@"extIAP mm: Successful Purchase");
+            NSLog(@"extIAP mm: Successful Purchase");
             NSString* receiptString = [[NSString alloc] initWithString:transaction.payment.productIdentifier];
 
             NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
@@ -257,18 +257,18 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
             sendPurchaseFinishEvent("success", [transaction.payment.productIdentifier UTF8String], [transaction.transactionIdentifier UTF8String], ([transaction.transactionDate timeIntervalSince1970] * 1000), [jsonObjectString UTF8String]);
 		}
 		@catch (NSException *exception) {
-			nslog(@"extIAP mm: %@", exception.reason);
+			NSLog(@"extIAP mm: %@", exception.reason);
 		}
 	}
     
     else
     {
-    	nslog(@"extIAP mm: Failed Purchase");
+    	NSLog(@"extIAP mm: Failed Purchase");
 
         [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
         if (transaction.error.code != SKErrorPaymentCancelled)
         {
-            nslog(@"extIAP mm: Transaction error: %@", transaction.error.localizedDescription);
+            NSLog(@"extIAP mm: Transaction error: %@", transaction.error.localizedDescription);
         }
         /* Pass error message instead of transaction.payment.productIdentifier */
         sendPurchaseEventWrap("failed", transaction.error.localizedDescription);
@@ -283,7 +283,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 		[[SKPaymentQueue defaultQueue] startDownloads:transaction.downloads];
 		
 	} else {
-		nslog(@"extIAP mm: Finish Transaction");
+		NSLog(@"extIAP mm: Finish Transaction");
 		[self finishTransaction:transaction wasSuccessful:YES];
 	}
 }
@@ -296,7 +296,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
     }
     else
     {
-    	nslog(@"extIAP mm: Canceled Purchase");
+    	NSLog(@"extIAP mm: Canceled Purchase");
     	sendPurchaseEventWrap("cancel", transaction.payment.productIdentifier);
         [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
     }
@@ -305,24 +305,24 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 - (void) updateAllTransactionsManually
 {
     NSArray * transactions = [[SKPaymentQueue defaultQueue] transactions];
-    nslog(@"extIAP mm: manual updatedTransactions count %lu", (unsigned long)[transactions count]);
+    NSLog(@"extIAP mm: manual updatedTransactions count %lu", (unsigned long)[transactions count]);
     
     for(SKPaymentTransaction *transaction in transactions)
     {
         switch(transaction.transactionState)
         {
             case SKPaymentTransactionStatePurchased:
-		nslog(@"extIAP mm: SKPaymentTransactionStatePurchased");
+		NSLog(@"extIAP mm: SKPaymentTransactionStatePurchased");
                 [self completeTransaction:transaction];
 		break;
 
             case SKPaymentTransactionStateRestored:
-		nslog(@"extIAP mm: SKPaymentTransactionStateRestored");
+		NSLog(@"extIAP mm: SKPaymentTransactionStateRestored");
                 [self completeTransaction:transaction];
                 break;
                 
             case SKPaymentTransactionStateFailed:
-		nslog(@"extIAP mm: SKPaymentTransactionStateFailed");
+		NSLog(@"extIAP mm: SKPaymentTransactionStateFailed");
                 [self failedTransaction:transaction];
                 break;
                 
@@ -342,7 +342,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray*)transactions
 {
-	nslog(@"extIAP mm: auto updatedTransactions");
+	NSLog(@"extIAP mm: auto updatedTransactions");
 	[self updateAllTransactionsManually];
 }
 
@@ -352,13 +352,13 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
     {
         switch (download.downloadState) {
             case SKDownloadStateActive:
-                nslog(@"extIAP mm: Download progress = %f and Download time: %f", download.progress, download.timeRemaining);
+                NSLog(@"extIAP mm: Download progress = %f and Download time: %f", download.progress, download.timeRemaining);
 				
 				//sendPurchaseDownloadEvent("downloadProgress", [download.contentIdentifier UTF8String], [download.transaction.transactionIdentifier UTF8String], [[download.contentURL absoluteString] UTF8String], [download.contentVersion UTF8String], [[NSString stringWithFormat:@"%f", download.progress] UTF8String]);
 				
                 break;
             case SKDownloadStateFinished:
-                nslog(@"extIAP mm: Download complete: %@",download.contentURL);
+                NSLog(@"extIAP mm: Download complete: %@",download.contentURL);
 				
 				//sendPurchaseDownloadEvent("downloadComplete", [download.contentIdentifier UTF8String], [download.transaction.transactionIdentifier UTF8String], [[download.contentURL absoluteString] UTF8String], [download.contentVersion UTF8String], nil);
 				
@@ -376,20 +376,20 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue
 {
-	nslog(@"extIAP mm: Restore complete!");
+	NSLog(@"extIAP mm: Restore complete!");
 	sendPurchaseEventWrap("productsRestored", @"");
 }
 
 - (void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
-	nslog(@"extIAP mm: Error restoring transactions");
+	NSLog(@"extIAP mm: Error restoring transactions");
 	sendPurchaseEventWrap("productsRestoredWithErrors", @"");
 	
 }
 
 - (void)dealloc
 {
-    nslog(@"extIAP mm: dealloc inapppurchase");
+    NSLog(@"extIAP mm: dealloc inapppurchase");
     
 	if(products)
         [products release];

--- a/project/iphone/InAppPurchase.mm
+++ b/project/iphone/InAppPurchase.mm
@@ -213,7 +213,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 - (BOOL) finishTransactionManually:(NSString *)transactionID
 {
     NSArray * transactions = [[SKPaymentQueue defaultQueue] transactions];
-
+    NSLog(@"extIAP mm: finish manually: %@", transactionID);
 		// if manualTransactionMode is set to flase, successful transaction will NEVER be finished!
     if (manualTransactionMode && transactions) {
         // 'transactions' contains SKPaymentTransaction, find the appropriate transaction
@@ -226,6 +226,8 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
         // transaction identifier was not found, quick developer log and return failure
         NSLog(@"extIAP mm: Failed to complete transaction manually. [expected_transaction=%@; open_transactions=%@]", transactionID, [[transactions valueForKey:@"transactionIdentifier"] componentsJoinedByString:@", "]);
+    } else {
+        NSLog(@"extIAP mm: couldn't finish manually: %d - %lu", manualTransactionMode, [transactions count]);
     }
     return false;
 }

--- a/project/iphone/InAppPurchase.mm
+++ b/project/iphone/InAppPurchase.mm
@@ -66,7 +66,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 		preInited = true;
 		static dispatch_once_t onceToken;
 		manualTransactionMode = true;
-		NSLog(@"xxxxxxx purchase init v2");
+		nslog(@"extIAP mm: xxxxxxx purchase init v2");
 		//dispatch_once(&onceToken, ^{
 			[[SKPaymentQueue defaultQueue] addTransactionObserver:self];
 		//});
@@ -85,14 +85,14 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
 - (void)checkQueue
 {
-    NSLog(@"checkQueue");
+    nslog(@"extIAP mm: checkQueue");
     
 	[self paymentQueue:[SKPaymentQueue defaultQueue] updatedTransactions:[[SKPaymentQueue defaultQueue] transactions]];
 }
 
 - (void)restorePurchases 
 {
-	NSLog(@"starting restore");
+	nslog(@"extIAP mm: starting restore");
 	[[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 
@@ -106,14 +106,14 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 	SKProduct* product = [self findProduct:productIdentifiers];//findProduct(productIdentifiers);
 	if (product != nil)
 	{
-		NSLog(@"product found");
+		nslog(@"extIAP mm: product found");
 		SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
         	payment.quantity = 1;
 		[[SKPaymentQueue defaultQueue] addPayment:payment];
 	}
 	else
 	{
-		NSLog(@"product not found");
+		nslog(@"extIAP mm: product not found");
 	}
 } 
 
@@ -121,7 +121,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 {
 	if(productsRequest != NULL)
 	{
-		NSLog(@"Can't request product data while performing a previous transaction.");
+		nslog(@"extIAP mm: Can't request product data while performing a previous transaction.");
 		return;
 	}
 
@@ -150,7 +150,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
 - (void)request:(SKProductsRequest *)request didFailWithError:(NSError *)error
 {
-	NSLog(@"Error: %@",error);
+	nslog(@"extIAP mm: Error: %@",error);
 	if( productsRequest == request ) productsRequest = NULL;
 	
 	sendPurchaseEventWrap("productDataFailed", error.localizedDescription);
@@ -159,8 +159,8 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse*)response
 {   	
 	int count = [response.products count];
-    	NSLog(@"productsRequest");
-	NSLog(@"Number of Products: %i", count);
+    	nslog(@"extIAP mm: productsRequest");
+	nslog(@"extIAP mm: Number of Products: %i", count);
 
 	// release the products request BEFORE calling the completion to support calling purchase()
 	// in the completion result handlers
@@ -197,7 +197,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
     
     else 
     {
-		NSLog(@"No products are available");
+		nslog(@"extIAP mm: No products are available");
 	}
 }
 
@@ -214,7 +214,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
         }
 
         // transaction identifier was not found, quick developer log and return failure
-        NSLog(@"Failed to complete transaction manually. [expected_transaction=%@; open_transactions=%@]", transactionID, [[transactions valueForKey:@"transactionIdentifier"] componentsJoinedByString:@", "]);
+        nslog(@"extIAP mm: Failed to complete transaction manually. [expected_transaction=%@; open_transactions=%@]", transactionID, [[transactions valueForKey:@"transactionIdentifier"] componentsJoinedByString:@", "]);
     }
     return false;
 }
@@ -229,7 +229,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
         }*/
 
         @try {
-            NSLog(@"Successful Purchase");
+            nslog(@"extIAP mm: Successful Purchase");
             NSString* receiptString = [[NSString alloc] initWithString:transaction.payment.productIdentifier];
 
             NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
@@ -257,18 +257,18 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
             sendPurchaseFinishEvent("success", [transaction.payment.productIdentifier UTF8String], [transaction.transactionIdentifier UTF8String], ([transaction.transactionDate timeIntervalSince1970] * 1000), [jsonObjectString UTF8String]);
 		}
 		@catch (NSException *exception) {
-			NSLog(@"%@", exception.reason);
+			nslog(@"extIAP mm: %@", exception.reason);
 		}
 	}
     
     else
     {
-    	NSLog(@"Failed Purchase");
+    	nslog(@"extIAP mm: Failed Purchase");
 
         [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
         if (transaction.error.code != SKErrorPaymentCancelled)
         {
-            NSLog(@"Transaction error: %@", transaction.error.localizedDescription);
+            nslog(@"extIAP mm: Transaction error: %@", transaction.error.localizedDescription);
         }
         /* Pass error message instead of transaction.payment.productIdentifier */
         sendPurchaseEventWrap("failed", transaction.error.localizedDescription);
@@ -283,7 +283,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 		[[SKPaymentQueue defaultQueue] startDownloads:transaction.downloads];
 		
 	} else {
-		NSLog(@"Finish Transaction");
+		nslog(@"extIAP mm: Finish Transaction");
 		[self finishTransaction:transaction wasSuccessful:YES];
 	}
 }
@@ -296,7 +296,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
     }
     else
     {
-    	NSLog(@"Canceled Purchase");
+    	nslog(@"extIAP mm: Canceled Purchase");
     	sendPurchaseEventWrap("cancel", transaction.payment.productIdentifier);
         [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
     }
@@ -305,24 +305,24 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 - (void) updateAllTransactionsManually
 {
     NSArray * transactions = [[SKPaymentQueue defaultQueue] transactions];
-    NSLog(@"manual updatedTransactions count %lu", (unsigned long)[transactions count]);
+    nslog(@"extIAP mm: manual updatedTransactions count %lu", (unsigned long)[transactions count]);
     
     for(SKPaymentTransaction *transaction in transactions)
     {
         switch(transaction.transactionState)
         {
             case SKPaymentTransactionStatePurchased:
-		NSLog(@"SKPaymentTransactionStatePurchased");
+		nslog(@"extIAP mm: SKPaymentTransactionStatePurchased");
                 [self completeTransaction:transaction];
 		break;
 
             case SKPaymentTransactionStateRestored:
-		NSLog(@"SKPaymentTransactionStateRestored");
+		nslog(@"extIAP mm: SKPaymentTransactionStateRestored");
                 [self completeTransaction:transaction];
                 break;
                 
             case SKPaymentTransactionStateFailed:
-		NSLog(@"SKPaymentTransactionStateFailed");
+		nslog(@"extIAP mm: SKPaymentTransactionStateFailed");
                 [self failedTransaction:transaction];
                 break;
                 
@@ -342,7 +342,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray*)transactions
 {
-	NSLog(@"auto updatedTransactions");
+	nslog(@"extIAP mm: auto updatedTransactions");
 	[self updateAllTransactionsManually];
 }
 
@@ -352,13 +352,13 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
     {
         switch (download.downloadState) {
             case SKDownloadStateActive:
-                NSLog(@"Download progress = %f and Download time: %f", download.progress, download.timeRemaining);
+                nslog(@"extIAP mm: Download progress = %f and Download time: %f", download.progress, download.timeRemaining);
 				
 				//sendPurchaseDownloadEvent("downloadProgress", [download.contentIdentifier UTF8String], [download.transaction.transactionIdentifier UTF8String], [[download.contentURL absoluteString] UTF8String], [download.contentVersion UTF8String], [[NSString stringWithFormat:@"%f", download.progress] UTF8String]);
 				
                 break;
             case SKDownloadStateFinished:
-                NSLog(@"Download complete: %@",download.contentURL);
+                nslog(@"extIAP mm: Download complete: %@",download.contentURL);
 				
 				//sendPurchaseDownloadEvent("downloadComplete", [download.contentIdentifier UTF8String], [download.transaction.transactionIdentifier UTF8String], [[download.contentURL absoluteString] UTF8String], [download.contentVersion UTF8String], nil);
 				
@@ -376,20 +376,20 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue
 {
-	NSLog(@"Restore complete!");
+	nslog(@"extIAP mm: Restore complete!");
 	sendPurchaseEventWrap("productsRestored", @"");
 }
 
 - (void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error
 {
-	NSLog(@"Error restoring transactions");
+	nslog(@"extIAP mm: Error restoring transactions");
 	sendPurchaseEventWrap("productsRestoredWithErrors", @"");
 	
 }
 
 - (void)dealloc
 {
-    NSLog(@"dealloc inapppurchase");
+    nslog(@"extIAP mm: dealloc inapppurchase");
     
 	if(products)
         [products release];

--- a/project/iphone/InAppPurchase.mm
+++ b/project/iphone/InAppPurchase.mm
@@ -53,6 +53,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 - (BOOL)canMakePurchases;
 - (void)purchaseProduct:(NSString*)productIdentifiers;
 - (void)requestProductData:(NSString*)productIdentifiers;
+- (void)processTransaction:(SKPaymentTransaction*)transaction wasSuccessful:(BOOL)wasSuccessful;
 - (BOOL)finishTransactionManually:(NSString *)transactionID;
 - (SKProduct*)findProduct:(NSString*)productIdentifier;
 
@@ -79,11 +80,12 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 		//});
 	}
     
+	sendPurchaseEventWrap("started", @"");
+
 	NSUInteger nbTransaction = [[SKPaymentQueue defaultQueue].transactions count];
 	if (nbTransaction > 0) {
 		[self updateAllTransactionsManually];
 	}
-	sendPurchaseEventWrap("started", @"");
     
     //[self checkQueue];
     //inited = true;
@@ -211,6 +213,8 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 - (BOOL) finishTransactionManually:(NSString *)transactionID
 {
     NSArray * transactions = [[SKPaymentQueue defaultQueue] transactions];
+
+		// if manualTransactionMode is set to flase, successful transaction will NEVER be finished!
     if (manualTransactionMode && transactions) {
         // 'transactions' contains SKPaymentTransaction, find the appropriate transaction
         for (SKPaymentTransaction * transaction in transactions) {
@@ -226,7 +230,8 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
     return false;
 }
 
-- (void)finishTransaction:(SKPaymentTransaction*)transaction wasSuccessful:(BOOL)wasSuccessful
+// renamed finishTransaction to processTransaction, because it doesn't always finish the transaction!
+- (void)processTransaction:(SKPaymentTransaction*)transaction wasSuccessful:(BOOL)wasSuccessful
 {
     if(wasSuccessful)
     {
@@ -291,7 +296,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 		
 	} else {
 		NSLog(@"extIAP mm: Finish Transaction");
-		[self finishTransaction:transaction wasSuccessful:YES];
+		[self processTransaction:transaction wasSuccessful:YES];
 	}
 }
 
@@ -299,7 +304,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 {
     if(transaction.error.code != SKErrorPaymentCancelled)
     {
-        [self finishTransaction:transaction wasSuccessful:NO];
+        [self processTransaction:transaction wasSuccessful:NO];
     }
     else
     {
@@ -370,7 +375,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 				
 				//sendPurchaseDownloadEvent("downloadComplete", [download.contentIdentifier UTF8String], [download.transaction.transactionIdentifier UTF8String], [[download.contentURL absoluteString] UTF8String], [download.contentVersion UTF8String], nil);
 				
-				[self finishTransaction:download.transaction wasSuccessful:YES];
+				[self processTransaction:download.transaction wasSuccessful:YES];
                 // Download is complete. Content file URL is at
                 // path referenced by download.contentURL. Move
                 // it somewhere safe, unpack it and give the user

--- a/project/iphone/InAppPurchase.mm
+++ b/project/iphone/InAppPurchase.mm
@@ -4,6 +4,9 @@
 #include "InAppPurchase.h"
 #include "InAppPurchaseEvent.h"
 
+//////////////////////////           //////////////////////////
+////////////////////////// CALLBACKS //////////////////////////
+//////////////////////////           //////////////////////////
 
 extern "C" void sendPurchaseEvent(const char* type, const char* data);
 extern "C" void sendPurchaseFinishEvent(const char* type, const char* productID, const char* transactionID, double transactionDate, const char* receipt);
@@ -31,6 +34,10 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
   		sendPurchaseProductDataEvent(type, [productID UTF8String], [localizedTitle UTF8String], [localizedDescription UTF8String], priceAmountMicros, [localizedPrice UTF8String], [priceCurrencyCode UTF8String], [priceCountryCode UTF8String]);
 	});
 }
+
+//////////////////////////                     //////////////////////////
+////////////////////////// InAppPurchase class //////////////////////////
+//////////////////////////                     //////////////////////////
 
 @interface InAppPurchase: NSObject <SKProductsRequestDelegate, SKPaymentTransactionObserver>
 {
@@ -312,17 +319,17 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
         switch(transaction.transactionState)
         {
             case SKPaymentTransactionStatePurchased:
-		NSLog(@"extIAP mm: SKPaymentTransactionStatePurchased");
-                [self completeTransaction:transaction];
-		break;
+							NSLog(@"extIAP mm: SKPaymentTransactionStatePurchased: %@", transaction.payment.productIdentifier);
+              [self completeTransaction:transaction];
+							break;
 
             case SKPaymentTransactionStateRestored:
-		NSLog(@"extIAP mm: SKPaymentTransactionStateRestored");
-                [self completeTransaction:transaction];
-                break;
+		  				NSLog(@"extIAP mm: SKPaymentTransactionStateRestored: %@", transaction.payment.productIdentifier);
+              [self completeTransaction:transaction];
+              break;
                 
             case SKPaymentTransactionStateFailed:
-		NSLog(@"extIAP mm: SKPaymentTransactionStateFailed");
+								NSLog(@"extIAP mm: SKPaymentTransactionStateFailed: %@", transaction.payment.productIdentifier);
                 [self failedTransaction:transaction];
                 break;
                 
@@ -335,6 +342,7 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
                 break;
 			*/
             default:
+								NSLog(@"extIAP mm: transaction update at state %ld for %@", (long)transaction.transactionState, transaction.payment.productIdentifier);
                 break;
         }
     }
@@ -401,6 +409,10 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 }
 
 @end
+
+//////////////////////////           //////////////////////////
+//////////////////////////  EXTERNS  //////////////////////////
+//////////////////////////           //////////////////////////
 
 extern "C"
 {


### PR DESCRIPTION
1. Inventory logic is updated to be similar to the Inventory logic on Android:
   - the purchase is removed from Inventory when consumed
   - acknowledged property is set to true when the purchase is acknowledged

2. If the purchase is acknowledged, the HX calls transaction finish

3. queryInventory is added to unify with Android. With these changes the same code may be used for both platforms (except fro Restore, that could be also unified btw)

4. finishTransaction is renamed to processTransaction in MM because it doesn't always finish the transaction and it creates mess because it's too similar to [[SKPaymentQueue defaultQueue] finishTransaction:transaction]

5. More logs added to MM to allow better control over the IAP flow. All logs now have "extIAP mm:" prefix to let filter it easier. 